### PR TITLE
Added observer to handle webflow's slider restart

### DIFF
--- a/src/webflow/restartWebflow.ts
+++ b/src/webflow/restartWebflow.ts
@@ -1,4 +1,4 @@
-import { getSiteId } from '.';
+import { getSiteId, SLIDER_CSS_CLASSES } from '.';
 
 import type { WebflowModule } from './Webflow';
 
@@ -53,7 +53,26 @@ export const restartWebflow = async (modules?: WebflowModule[]): Promise<unknown
   if (modules?.includes('lightbox')) Webflow.require('lightbox')?.ready();
 
   // Slider
-  if (modules?.includes('slider')) Webflow.require('slider')?.redraw();
+  if (modules?.includes('slider')) {
+    const slider = Webflow.require('slider');
+
+    // identify an element to observe
+    const sliderToObserve = document.querySelector(SLIDER_CSS_CLASSES.slider);
+
+    if (sliderToObserve) {
+      const observer = new MutationObserver(() => {
+        if (slider) {
+          slider.ready();
+        }
+        observer.disconnect();
+      });
+      observer.observe(sliderToObserve, { attributeOldValue: true });
+    }
+
+    if (slider) {
+      slider.redraw();
+    }
+  }
 
   // Tabs
   if (modules?.includes('tabs')) Webflow.require('tabs')?.redraw();


### PR DESCRIPTION
Issue: https://finsweet.slack.com/archives/C03JUS2JD3K/p1668012987041539

When running only redraw, it seems to lose context before completing execution.
```
  (h.redraw = function () {
    (y = !0), E(), (y = !1);
  }),
```

I've tried to run `ready` afterwards and didn't work at first try.
The `design` function has a timeout of `1e3`, so when I've add this timeout to `ready` it seems to work with 100% assertiveness.

Because timeout could be buggy, I've tried with observer, that can get the exact moment when `redraw` set the class name again. 

In local testing, the user's report seems to be solved.

@alexiglesias93 Let me know what you think about this approach, It would be great to have your knowledge to validate possible side effects and other things. 
