### PR TITLE
Added new `LooseAutocomplete` type

### DIFF
--- a/.changeset/gentle-dots-jump.md
+++ b/.changeset/gentle-dots-jump.md
@@ -1,0 +1,5 @@
+---
+'@finsweet/ts-utils': minor
+---
+
+Added new `LooseAutocomplete` type

--- a/docs/types.md
+++ b/docs/types.md
@@ -20,7 +20,7 @@ A type that allows for variable autocompletion with loose validation.
 Example:
 
 ```typescript
-const f = (a: LooseAutocomplete<'a' | 'b'>) => a;
+const f = (foo: LooseAutocomplete<'a' | 'b'>) => foo;
 f(''); // VSCode autocomplete shows 'a' and 'b' as options, but doesn't fail when a different option is provided.
 f('a'); // Valid
 f('b'); // Valid

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,5 +1,5 @@
 ---
-prev: 
+prev:
   text: 'Type Guards'
   link: '/type-guards'
 next:
@@ -9,10 +9,23 @@ next:
 
 # Types
 
-
 ## `FormField`
 
 `FormField` is the Form Field element on Webflow
+
+## `LooseAutocomplete`
+
+A type that allows for variable autocompletion with loose validation.
+
+Example:
+
+```typescript
+const f = (a: LooseAutocomplete<'a' | 'b'>) => a;
+f(''); // VSCode autocomplete shows 'a' and 'b' as options, but doesn't fail when a different option is provided.
+f('a'); // Valid
+f('b'); // Valid
+f('c'); // Valid
+```
 
 ## `MapEntries`
 

--- a/src/types/LooseAutocomplete.ts
+++ b/src/types/LooseAutocomplete.ts
@@ -1,0 +1,12 @@
+/**
+ * A type that allows for variable autocompletion with loose validation.
+ * @example
+ * ```typescript
+ * const f = (a: LooseAutocomplete<'a' | 'b'>) => a;
+ * f(''); // VSCode autocomplete shows 'a' and 'b' as options, but doesn't fail when a different option is provided.
+ * f('a'); // Valid
+ * f('b'); // Valid
+ * f('c'); // Valid
+ * ```
+ */
+export type LooseAutocomplete<T extends string | number | symbol> = T | Omit<string | number | symbol, T>;

--- a/src/types/LooseAutocomplete.ts
+++ b/src/types/LooseAutocomplete.ts
@@ -2,7 +2,7 @@
  * A type that allows for variable autocompletion with loose validation.
  * @example
  * ```typescript
- * const f = (a: LooseAutocomplete<'a' | 'b'>) => a;
+ * const f = (foo: LooseAutocomplete<'a' | 'b'>) => foo;
  * f(''); // VSCode autocomplete shows 'a' and 'b' as options, but doesn't fail when a different option is provided.
  * f('a'); // Valid
  * f('b'); // Valid

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export * as Greenhouse from './apis/Greenhouse';
 export type { Entry } from './Entry';
 export type { FormField } from './FormField';
 export type { Instance } from './Instance';
+export type { LooseAutocomplete } from './LooseAutocomplete';
 export type { MapEntries } from './MapEntries';
 export type { PartialExcept } from './PartialExcept';
 export type { PickPartial } from './PickPartial';


### PR DESCRIPTION
## `LooseAutocomplete`

A type that allows for variable autocompletion with loose validation.

Example:

```typescript
const f = (foo: LooseAutocomplete<'a' | 'b'>) => foo;
f(''); // VSCode autocomplete shows 'a' and 'b' as options, but doesn't fail when a different option is provided.
f('a'); // Valid
f('b'); // Valid
f('c'); // Valid
```